### PR TITLE
Add a summary testcase

### DIFF
--- a/judiff.py
+++ b/judiff.py
@@ -38,7 +38,7 @@ comp_extra_failures = []
 comp_extra_skipped = []
 gold_extra_failures = []
 gold_extra_skipped = []
-tests_not_in_gold = []
+tests_not_in_gold = {"failed": [], "skipped": [], "passed": []}
 
 
 def append_status(prefix, node, diff_list):
@@ -86,7 +86,7 @@ for testcase in testtree.findall('testcase'):
     name = testcase.attrib['classname'] + ":" + testcase.attrib['name']
     status = test_status(testcase)
     if name not in gold_status:
-        tests_not_in_gold.append(name)
+        tests_not_in_gold[status].append(name)
         continue
     elif status == gold_status[name]:
         testroot.remove(testcase)
@@ -111,8 +111,10 @@ append_status("\nTests skipped in comp:\n", summary_sys_out, comp_extra_skipped)
 append_status("\nTests failed in gold:\n", summary_sys_out, gold_extra_failures)
 append_status("\nTests skipped in gold:\n", summary_sys_out, gold_extra_skipped)
 summary_sys_out.text += "\nTests not found in gold xml:\n"
-for i in tests_not_in_gold:
-    summary_sys_out.text += "\n" + i
+for k, v in tests_not_in_gold.items():
+    summary_sys_out.text += "\n    " + k + ":\n"
+    for name in v:
+        summary_sys_out.text += "        " + i + "\n"
 
 if comp_extra_failures or comp_extra_skipped:
     msg = "Additional failures/skipped tests compared to gold"

--- a/judiff.py
+++ b/judiff.py
@@ -114,7 +114,7 @@ summary_sys_out.text += "\nTests not found in gold xml:\n"
 for k, v in tests_not_in_gold.items():
     summary_sys_out.text += "\n    " + k + ":\n"
     for name in v:
-        summary_sys_out.text += "        " + i + "\n"
+        summary_sys_out.text += "        " + name + "\n"
 
 if comp_extra_failures or comp_extra_skipped:
     msg = "Additional failures/skipped tests compared to gold"

--- a/judiff.py
+++ b/judiff.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#-
+# -
 # Copyright (c) 2016 SRI International
 # All rights reserved.
 #
@@ -28,53 +28,56 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #
-
+from __future__ import print_function
 import sys
 import xml.etree.ElementTree as ET
 
 gold_status = {}
 
-def usage():
-	print "usage: " + sys.argv[0] + " <gold-file> <comp-file> <outfile>"
-	exit(1)
 
-def test_status( test ):
-	failure = testcase.find('failure')
-	skipped = testcase.find('skipped')
-	if not failure is None:
-		return "failed"
-	if not skipped is None:
-		return "skiped"
-	return "passed"
+def usage():
+    print("usage: " + sys.argv[0] + " <gold-file> <comp-file> <outfile>")
+    exit(1)
+
+
+def test_status(test):
+    failure = testcase.find('failure')
+    skipped = testcase.find('skipped')
+    if failure is not None:
+        return "failed"
+    if skipped is not None:
+        return "skipped"
+    return "passed"
+
 
 if len(sys.argv) != 4:
-	usage()
-goldfile=sys.argv[1]
-testfile=sys.argv[2]
-outfile=sys.argv[3]
+    usage()
+goldfile = sys.argv[1]
+testfile = sys.argv[2]
+outfile = sys.argv[3]
 
 goldtree = ET.parse(goldfile)
 goldroot = goldtree.getroot()
 
 for testcase in goldroot.findall('testcase'):
-	name = testcase.attrib['classname'] + ":" + testcase.attrib['name']
-	gold_status[name] = test_status(testcase)
+    name = testcase.attrib['classname'] + ":" + testcase.attrib['name']
+    gold_status[name] = test_status(testcase)
 
 testtree = ET.parse(testfile)
 testroot = testtree.getroot()
-judc = ET.SubElement(testroot, 'testcase', attrib={'classname':"judiff", 'name':"status"})
+judc = ET.SubElement(testroot, 'testcase', attrib={'classname': "judiff", 'name': "status"})
 sys_out = ET.SubElement(judc, 'system-out')
 sys_out.text = "Input files:\ngold: " + goldfile + "\ncompare: " + testfile + "\n"
 sys_error = ET.SubElement(judc, 'system-err')
 sys_error.text = "Identical tests removed:\n"
 for testcase in testtree.findall('testcase'):
-	name = testcase.attrib['classname'] + ":" + testcase.attrib['name']
-	status = test_status(testcase)
-	if not name in gold_status:
-		continue
-	elif status == gold_status[name]:
-		testroot.remove(testcase)
-		sys_error.text += "classname: " + testcase.attrib['classname'] + " "
-		sys_error.text += "name: " + testcase.attrib['name'] + "\n"
+    name = testcase.attrib['classname'] + ":" + testcase.attrib['name']
+    status = test_status(testcase)
+    if not name in gold_status:
+        continue
+    elif status == gold_status[name]:
+        testroot.remove(testcase)
+        sys_error.text += "classname: " + testcase.attrib['classname'] + " "
+        sys_error.text += "name: " + testcase.attrib['name'] + "\n"
 
 testtree.write(outfile)


### PR DESCRIPTION
Example from Jenkins:
```
Error Message
Additional failures/skipped tests compared to gold
Standard Output
Summary:
gold: BASE_ABI=cheriabi_static,CPU=cheri,TEST_SELECTOR=cheri/lib:,label=freebsd/cheri-cheri-lib:-test-results.xml
compare: BASE_ABI=cheriabi,CPU=cheri,TEST_SELECTOR=cheri/lib:,label=freebsd/cheri-cheri-lib:-test-results.xml

Tests failed in comp:
    libc.db.db_test:btree_byteswap_unaligned_access_bksd (failed vs passed)
    libc.db.db_test:btree_byteswap_unaligned_access_skbd (failed vs passed)
    libc.db.db_test:btree_known_byte_order (failed vs passed)
    libc.db.db_test:btree_tricky_page_split (failed vs passed)
    libc.db.db_test:repeated_btree (failed vs passed)
    libc.gen.wordexp_test:long_output_test (failed vs passed)
    libc.net.protoent_test:protoent (failed vs passed)
    libc.sys.getlogin_test:setlogin_err (failed vs passed)

Tests skipped in comp:

Tests failed in gold:
    libc.iconv.iconvctl_test:iconvctl_trivialp_test (failed vs passed)
    libc.locale.c16rtomb_test:c16rtomb_c_locale_test (failed vs passed)
    libc.locale.c16rtomb_test:c16rtomb_iso_8859_15_test (failed vs passed)
    libc.locale.c16rtomb_test:c16rtomb_iso_8859_1_test (failed vs passed)
    libc.locale.c16rtomb_test:c16rtomb_utf_8_test (failed vs passed)
    libc.locale.mbrtoc16_test:mbrtoc16_c_locale_test (failed vs passed)
    libc.locale.mbrtoc16_test:mbrtoc16_iso_8859_15_test (failed vs passed)
    libc.locale.mbrtoc16_test:mbrtoc16_iso_8859_1_test (failed vs passed)
    libc.locale.mbrtoc16_test:mbrtoc16_utf_8_test (failed vs passed)
    libc.net.nsdispatch_test:recurse (failed vs passed)
    libc.setjmp.setjmp_test:setjmp (failed vs passed)
    libc.string.wcscoll_test:strcoll_vs_strxfrm (failed vs passed)
    libthr.atexit_test:atexit (failed vs passed)
    libthr.cancel_test:register_while_disabled (failed vs passed)
    libthr.exit_test:main_thread (failed vs passed)

Tests skipped in gold:
    libxo.functional_test:test_01__E (skipped vs passed)
    libxo.functional_test:test_02__E (skipped vs passed)
    libxo.functional_test:test_03__E (skipped vs passed)
    libxo.functional_test:test_04__E (skipped vs passed)
    libxo.functional_test:test_05__E (skipped vs passed)
    libxo.functional_test:test_06__E (skipped vs passed)
    libxo.functional_test:test_07__E (skipped vs passed)
    libxo.functional_test:test_08__E (skipped vs passed)
    libxo.functional_test:test_09__E (skipped vs passed)
    libxo.functional_test:test_10__E (skipped vs passed)
    libxo.functional_test:test_11__E (skipped vs passed)
```